### PR TITLE
Add linux wheel support for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,36 @@ jobs:
           tags: true
 
     - stage: wheels
+      name: Wheels for aarch64 Linux
+      os: linux
+      language: python
+      python:
+        - "3.6"
+      arch: arm64
+      install:
+        - pip install --upgrade pip setuptools
+        - pip install cython cibuildwheel~=1.8.0
+
+      script:
+        - cibuildwheel --output-dir wheelhouse
+
+      env:
+        - CIBW_BUILD='*p3*'
+        - CIBW_BEFORE_BUILD='pip install cython'
+      deploy:
+        name: Linux
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: wheelhouse/*
+        skip_cleanup: true
+        draft: true
+        prerelease: true
+        overwrite: true
+        on:
+          tags: true
+
+    - stage: wheels
       name: Wheels for OS X
       os: osx
       language: generic


### PR DESCRIPTION
**Package Owner**: Disha Srivastava

**PR change Details:** Added linux aarch64 wheel support.

**Testing Detail** : Test logs: https://travis-ci.com/github/dish59742/clickhouse-driver/jobs/488413588

**Peer Reviewer:** Madhukar

**Reviewer:** Pruthvi